### PR TITLE
feat: 등기부등본 권리분석 기능 구현 및 고유번호 기반 조회 흐름 통합

### DIFF
--- a/.idea/modules/RealtyWeb.main.iml
+++ b/.idea/modules/RealtyWeb.main.iml
@@ -10,7 +10,9 @@
       <configuration>
         <setting name="validation-enabled" value="true" />
         <setting name="provider-name" value="Hibernate" />
-        <datasource-mapping />
+        <datasource-mapping>
+          <factory-entry name="entityManagerFactory" />
+        </datasource-mapping>
         <naming-strategy-map />
       </configuration>
     </facet>

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' //Jackson을 사용
 
+	// Codef
+	implementation 'io.codef.api:easycodef-java:1.0.6'
+
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 

--- a/src/main/java/com/Realty/RealtyWeb/Config/CodefConfig.java
+++ b/src/main/java/com/Realty/RealtyWeb/Config/CodefConfig.java
@@ -1,0 +1,27 @@
+package com.Realty.RealtyWeb.Config;
+
+import io.codef.api.EasyCodef;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CodefConfig {
+
+    @Value("${codef.client-id}")
+    private String clientId;
+
+    @Value("${codef.client-secret}")
+    private String clientSecret;
+
+    @Value("${codef.public-key}")
+    private String publicKey;
+
+    @Bean
+    public EasyCodef codefClient() {
+        EasyCodef codef = new EasyCodef();
+        codef.setClientInfoForDemo(clientId, clientSecret);
+        codef.setPublicKey(publicKey);
+        return codef;
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/Config/WebSecurityConfig.java
+++ b/src/main/java/com/Realty/RealtyWeb/Config/WebSecurityConfig.java
@@ -60,7 +60,13 @@ public class WebSecurityConfig{
                             .requestMatchers("/api/auth/token/refresh").permitAll()
                             .requestMatchers("/api/member/list").permitAll()
                             .requestMatchers("/api/member/find-password").permitAll()
+                            .requestMatchers("/api/codef/register").permitAll()
+                            .requestMatchers("/api/codef/register/2way").permitAll()
+                            .requestMatchers("/api/codef/register/auto").permitAll()
+                            .requestMatchers("/api/codef/unique").permitAll()
 
+                            .requestMatchers("/api/analysis/**").authenticated()
+                            .requestMatchers("/api/analysis/**").authenticated()
                             .requestMatchers("/api/Realty/chat").authenticated()
                             .requestMatchers("/api/house-board/**").authenticated()
                             .requestMatchers("/api/house-info/**").authenticated()

--- a/src/main/java/com/Realty/RealtyWeb/Entity/HouseInfoEntity.java
+++ b/src/main/java/com/Realty/RealtyWeb/Entity/HouseInfoEntity.java
@@ -5,6 +5,8 @@ import com.Realty.RealtyWeb.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "house_info")
 @Getter
@@ -39,10 +41,10 @@ public class HouseInfoEntity {
     private TransactionType transactionType;  // 거래 유형
 
     @Column(nullable = false, columnDefinition = "DECIMAL(15,2)")
-    private Double price;  // 가격
+    private BigDecimal price;  // 가격
 
     @Column(name = "maintenance_fee", nullable = false, columnDefinition = "DECIMAL(10,2)")
-    private Double maintenanceFee;  // 관리비
+    private BigDecimal maintenanceFee;  // 관리비
 
     @Column(nullable = false, length = 255)
     private String address;  // 주소
@@ -51,10 +53,10 @@ public class HouseInfoEntity {
     private String addressDetail;  // 상세 주소
 
     @Column(name = "exclusive_area", nullable = false, columnDefinition = "DECIMAL(10,2)")
-    private Double exclusiveArea;  // 전용 면적 (㎡)
+    private BigDecimal exclusiveArea;  // 전용 면적 (㎡)
 
     @Column(name = "supply_area", nullable = false, columnDefinition = "DECIMAL(10,7)")
-    private Double supplyArea;  // 공급 면적 (㎡)
+    private BigDecimal supplyArea;  // 공급 면적 (㎡)
 
     @Column
     private Integer rooms;  // 방 개수

--- a/src/main/java/com/Realty/RealtyWeb/Entity/RegisterAnalysisEntity.java
+++ b/src/main/java/com/Realty/RealtyWeb/Entity/RegisterAnalysisEntity.java
@@ -1,0 +1,79 @@
+package com.Realty.RealtyWeb.Entity;
+
+import com.Realty.RealtyWeb.enums.Purpose;
+import com.Realty.RealtyWeb.enums.RiskLevel;
+import com.Realty.RealtyWeb.enums.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/*
+
+CREATE TABLE register_analysis (
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    pid             BIGINT NOT NULL,  -- house_board.id 참조
+    risk_level ENUM('안전', '주의', '위험') DEFAULT '주의',
+    issue_date      DATETIME NOT NULL,  -- 등기부등본 발급일자
+    owner           VARCHAR(100),        -- 소유자 이름
+    risk_keywords   TEXT,                -- 위험 키워드 (콤마 구분: "가압류,가등기,근저당권")
+    main_warnings   TEXT,                -- 주요 경고 요약 문장 (UI에 그대로 출력)
+    max_claim       DECIMAL(15,2),       -- 채권최고액
+    protected_amount DECIMAL(15,2),      -- 보호 가능한 금액
+    pdf_base64      LONGTEXT,            -- 원문 PDF (Base64 인코딩)
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (pid) REFERENCES house_board(pid) ON DELETE CASCADE
+);
+
+ */
+@Entity
+@Table(name = "register_analysis")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterAnalysisEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String userid;
+
+    private Long pid;
+
+    @Enumerated(EnumType.STRING)
+    private RiskLevel risk_level;
+
+    private LocalDateTime issue_date;
+    private String owner;
+    private String risk_keywords;
+    private String main_warnings;
+
+    @Column(name = "max_claim")
+    private BigDecimal max_claim;
+
+    @Column(name = "protected_amount")
+    private BigDecimal protected_amount;
+
+    @Enumerated(EnumType.STRING)
+    private Purpose purpose;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+
+    @Column(columnDefinition = "DECIMAL(15,2)")
+    private BigDecimal price;
+    @Column(name = "exclusive_area", columnDefinition = "DECIMAL(10,2)")
+    private BigDecimal exclusiveArea;
+
+    @Lob
+    private String pdf_base64;
+    private LocalDateTime created_at;
+
+    @PrePersist
+    protected void onCreate() {
+        this.created_at = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/Mapper/RegisterAnalysisMapper.java
+++ b/src/main/java/com/Realty/RealtyWeb/Mapper/RegisterAnalysisMapper.java
@@ -1,0 +1,46 @@
+package com.Realty.RealtyWeb.Mapper;
+
+import com.Realty.RealtyWeb.dto.CodefResponseDTO;
+import com.Realty.RealtyWeb.dto.RegisterAnalysisDTO;
+import java.time.LocalDateTime;
+
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
+
+public class RegisterAnalysisMapper {
+    // Codef 답변과 매핑
+
+    public static RegisterAnalysisDTO fromCodefResponse(CodefResponseDTO dto, Long pid, String userid) {
+        CodefResponseDTO.PropertyBasicInfo info = dto.getPropertyInfo();
+        CodefResponseDTO.RiskReport report = dto.getRiskReport();
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime issueDate = LocalDateTime.parse(info.getResPublishDate(), formatter);
+
+        // 위험 키워드 추출
+        String keywords = report.getRisks().stream()
+                .map(CodefResponseDTO.RiskDetail::getCategory)
+                .distinct()
+                .collect(Collectors.joining(", "));
+
+        String warnings = report.getRisks().stream()
+                .map(CodefResponseDTO.RiskDetail::getDescription)
+                .distinct()
+                .collect(Collectors.joining(" / "));
+
+        return RegisterAnalysisDTO.builder()
+                .pid(pid)
+                .userid(userid)
+                .owner(info.getResUserNm())
+                .issueDate(issueDate)
+                .riskLevel(report.getOverallRisk())
+                .riskKeywords(keywords)
+                .mainWarnings(warnings)
+                .maxClaim(null)
+                .protectedAmount(null)
+                .pdfBase64(dto.getResOriGinalData())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/controller/CodefRegisterController.java
+++ b/src/main/java/com/Realty/RealtyWeb/controller/CodefRegisterController.java
@@ -1,0 +1,63 @@
+package com.Realty.RealtyWeb.controller;
+
+import com.Realty.RealtyWeb.dto.*;
+import com.Realty.RealtyWeb.services.CodefRegisterService;
+import com.Realty.RealtyWeb.services.HouseInfoService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/codef")
+@RequiredArgsConstructor
+public class CodefRegisterController {
+
+    private final CodefRegisterService codefRegisterService;
+    private final HouseInfoService houseInfoService;
+
+
+    // 1차 요청: 기본 입력으로 등기부 조회 시도
+//    @PostMapping("/register")
+//    public ResponseEntity<JsonNode> requestRegister(@RequestBody CodefRequestDTO dto) throws JsonProcessingException, NoSuchPaddingException, IllegalBlockSizeException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeySpecException, BadPaddingException, InvalidKeyException, InterruptedException {
+//
+//        JsonNode node = codefRegisterService.requestRegisterFirst(dto, houseInfoService.findAddressByPid(dto.getPid()));
+//
+//        // PDF/바이너리인 경우: binaryData 필드만 존재
+//        if (node.has("binaryData")) {
+//            return ResponseEntity.ok(node);    // 프론트에서 다운로드 처리
+//        }
+//        return ResponseEntity.ok(node);        // 정상 JSON
+//    }
+
+    // 고유번호 단일조회 - 테스트용
+    @PostMapping("/unique")
+    public ResponseEntity<JsonNode> byUnique(@RequestBody UniqueNoRequestDTO dto)
+            throws JsonProcessingException {
+
+        JsonNode res = codefRegisterService.requestByUnique(dto);
+
+        // ▸ PDF 라면 binaryData 래퍼, JSON 은 그대로
+        return ResponseEntity.ok(res);
+    }
+
+
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/controller/RegisterAnalysisController.java
+++ b/src/main/java/com/Realty/RealtyWeb/controller/RegisterAnalysisController.java
@@ -1,0 +1,74 @@
+package com.Realty.RealtyWeb.controller;
+
+import com.Realty.RealtyWeb.dto.RegisterAnalysisDTO;
+import com.Realty.RealtyWeb.services.RegisterAnalysisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Base64;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/analysis")
+public class RegisterAnalysisController {
+
+    private final RegisterAnalysisService registerAnalysisService;
+
+    // 사용자별 분석 이력 조회
+    @GetMapping("/list")
+    public ResponseEntity<List<RegisterAnalysisDTO>> getUserAnalyses(@AuthenticationPrincipal UserDetails userDetails) {
+        String userid = userDetails.getUsername();
+        List<RegisterAnalysisDTO> result = registerAnalysisService.getAllByUser(userid);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RegisterAnalysisDTO> getAnalysisDetail(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String userid = userDetails.getUsername();
+
+        RegisterAnalysisDTO result = registerAnalysisService.getByIdAndUser(id, userid);
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/pdf/{id}")
+    public ResponseEntity<byte[]> downloadPdf(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String userid = userDetails.getUsername();
+        RegisterAnalysisDTO dto = registerAnalysisService.getByIdAndUser(id, userid);
+
+        if (dto == null || dto.getPdfBase64() == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        byte[] decodedPdf = Base64.getDecoder().decode(dto.getPdfBase64());
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header("Content-Disposition", "attachment; filename=\"register-analysis-" + id + ".pdf\"")
+                .body(decodedPdf);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAnalysis(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails user
+    ) {
+        registerAnalysisService.deleteByIdAndUser(id, user.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/CodefRequestDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/CodefRequestDTO.java
@@ -1,0 +1,100 @@
+package com.Realty.RealtyWeb.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CodefRequestDTO {
+    @JsonProperty("organization")
+    private String organization;           // 기관코드 (ex: "0002")
+    @JsonProperty("phoneNo")
+    private String phoneNo;                // 전화번호
+    @JsonProperty("password")
+    private String password;               // 평문 비밀번호 (RSA 암호화 전)
+
+    @JsonProperty("inquiryType")
+    private String inquiryType;            // 조회구분 (0~3)
+    @JsonProperty("uniqueNo")
+    private String uniqueNo;               // 부동산 고유번호
+    @JsonProperty("realtyType")
+    private String realtyType;             // 부동산 구분
+
+    @JsonProperty("addr_sido")
+    private String addr_sido;              // 주소_시도
+    @JsonProperty("address")
+    private String address;                // 간편검색 주소
+
+    @JsonProperty("recordStatus")
+    private String recordStatus;           // 등기기록상태
+
+    @JsonProperty("addr_dong")
+    private String addr_dong;              // 주소_동
+    @JsonProperty("addr_lotNumber")
+    private String addr_lotNumber;         // 주소_지번
+    @JsonProperty("inputSelect")
+    private String inputSelect;            // 입력선택
+    @JsonProperty("buildingName")
+    private String buildingName;           // 건물명칭
+    @JsonProperty("dong")
+    private String dong;                   // 동 (집합건물)
+    @JsonProperty("ho")
+    private String ho;                     // 호 (집합건물)
+
+    @JsonProperty("addr_sigungu")
+    private String addr_sigungu;           // 주소_시군구
+    @JsonProperty("addr_roadName")
+    private String addr_roadName;          // 주소_도로명
+    @JsonProperty("addr_buildingNumber")
+    private String addr_buildingNumber;    // 주소_건물번호
+
+    @JsonProperty("jointMortgageJeonseYN")
+    private String jointMortgageJeonseYN;  // 공동담보/전세목록 포함여부
+    @JsonProperty("tradingYN")
+    private String tradingYN;              // 매매목록 포함여부
+    @JsonProperty("listNumber")
+    private String listNumber;             // 목록번호
+    @JsonProperty("electronicClosedYN")
+    private String electronicClosedYN;     // 전산폐쇄 포함여부
+
+    @JsonProperty("ePrepayNo")
+    private String ePrepayNo;              // 선불전자지급수단 번호
+
+    @JsonProperty("ePrepayPass")
+    private String ePrepayPass;            // 선불전자지급수단 비밀번호
+
+    @JsonProperty("issueType")
+    private String issueType;              // 발행구분
+    @JsonProperty("startPageNo")
+    private String startPageNo;            // 시작 페이지 번호
+    @JsonProperty("pageCount")
+    private String pageCount;              // 조회 페이지 수
+    @JsonProperty("originData")
+    private String originData;             // 원문 데이터
+    @JsonProperty("originDataYN")
+    private String originDataYN;           // 원문 포함 여부
+    @JsonProperty("warningSkipYN")
+    private String warningSkipYN;          // 경고 무시 여부
+    @JsonProperty("registerSummaryYN")
+    private String registerSummaryYN;      // 등기사항요약 출력 여부
+
+    @JsonProperty("applicationType")
+    private String applicationType;        // 신청구분
+
+    @JsonProperty("selectAddress")
+    private String selectAddress;          // 주소 리스트 선택 여부
+
+    @JsonProperty("isIdentityViewYn")
+    private String isIdentityViewYn;       // 주민등록번호 공개여부
+
+    @JsonProperty("identityList")
+    private List<Identity> identityList;   // 주민등록번호 리스트
+
+    @Data
+    public static class Identity {
+        @JsonProperty("reqIdentity")
+        private String reqIdentity;        // 주민등록번호 (13자리)
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/CodefResponseDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/CodefResponseDTO.java
@@ -1,0 +1,41 @@
+package com.Realty.RealtyWeb.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Builder
+public class CodefResponseDTO {
+
+    private PropertyBasicInfo propertyInfo;     // 기본 부동산 정보
+    private String resOriGinalData;             // 등기부등본 원문 (Base64)
+    private RiskReport riskReport;              // 리스크 분석 결과
+
+    @Data
+    @Builder
+    public static class PropertyBasicInfo {
+        private String resUserNm;                   // 소유자명
+        private String resRealty;                   // 부동산명
+        private String commUniqueNo;                // 고유번호
+        private String resPublishDate;              // 발급일자
+        private String commCompetentRegistryOffice; // 관할등기소
+    }
+
+    @Data
+    @Builder
+    public static class RiskReport {
+        private String overallRisk;                 // 최종판단 (없음 / 주의 / 위험)
+        private List<RiskDetail> risks;             // 리스크 상세 리스트
+    }
+
+    @Data
+    @Builder
+    public static class RiskDetail {
+        private String category;                    // 항목명 (예: 근저당권)
+        private String level;                       // 상태 (주의 / 위험)
+        private String description;                 // 설명
+    }
+}
+
+

--- a/src/main/java/com/Realty/RealtyWeb/dto/CodefTwoWayAuthRequestDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/CodefTwoWayAuthRequestDTO.java
@@ -1,0 +1,52 @@
+package com.Realty.RealtyWeb.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+/**
+ * 2-Way 인증(추가 인증) 요청용 DTO
+ *
+ * ✔️ 1차 요청에 사용한 모든 필드를 “평면” 구조로 그대로 보냅니다.
+ * ✔️ 2-Way 전용 필드(jobIndex · threadIndex · jti · twoWayTimestamp)는
+ *    중첩 객체(twoWayInfo)에 담아 전달합니다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodefTwoWayAuthRequestDTO {
+
+    /* ───── 2-Way 공통 필드 ───── */
+    private String  uniqueNo;   // 사용자가 선택한 부동산 고유번호
+    private boolean is2Way;     // true 고정
+
+    /* ───── 1차 요청에서 그대로 가져오는 필드 ───── */
+    @JsonProperty("organization")  private String organization;            // "0002"
+    @JsonProperty("phoneNo")       private String phoneNo;                 // 휴대폰번호
+    private String  password;                                             // 평문 비밀번호
+    private String  inquiryType;                                          // "1"
+    private String  issueType;                                            // "1"
+    private String  address;                                              // 간편검색 주소
+    private String  recordStatus;                                         // "0"
+    private String  jointMortgageJeonseYN;                                // "0"
+    private String  tradingYN;                                            // "0"
+    private String  electronicClosedYN;                                   // "0"
+    private String  ePrepayNo;                                            // 선불전자지급수단 번호
+    private String  ePrepayPass;                                          // 선불전자지급수단 비밀번호
+    private String  originDataYN;                                         // "1"
+    private String  warningSkipYN;                                        // "0"
+
+    /* ───── 2-Way 전용 정보 ───── */
+    private TwoWayInfo twoWayInfo;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TwoWayInfo {
+        private int    jobIndex;          // 0
+        private int    threadIndex;       // 0
+        private String jti;               // 응답에서 받은 jti
+        private long   twoWayTimestamp;   // 응답에서 받은 twoWayTimestamp
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/CodefTwoWayAuthResponseDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/CodefTwoWayAuthResponseDTO.java
@@ -1,0 +1,44 @@
+package com.Realty.RealtyWeb.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CodefTwoWayAuthResponseDTO {
+    private boolean continue2Way; //추가 인증 필요여부
+    private String method; //인증 방식
+    private int jobIndex;
+    private int threadIndex;
+    private String jti; //트랜잭션 ID
+    private long twoWayTimestamp; //인증 시간
+
+    private ExtraInfo extraInfo;
+
+    @Data
+    @Builder
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ExtraInfo {
+        private List<AddressCandidate> resAddrList;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddressCandidate {
+        private String commUniqueNo; //부동산 고유번호
+        private String commAddrLotNumber; //부동산 소재지번
+        private String resUserNm; //소유자명
+        private String resState; //상태
+        private String resType; //구분
+    }
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/HouseBoardSummaryDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/HouseBoardSummaryDTO.java
@@ -5,6 +5,8 @@ import com.Realty.RealtyWeb.Entity.HouseInfoEntity;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
+
 @Getter
 @Builder
 public class HouseBoardSummaryDTO {
@@ -13,8 +15,8 @@ public class HouseBoardSummaryDTO {
     private String ptitle;            // 제목
     private String houseType;         // 주택 유형
     private String transactionType;   // 거래 유형
-    private Double price;            // 거래 금액
-    private Double exclusiveArea;    // 전용면적
+    private BigDecimal price;            // 거래 금액
+    private BigDecimal exclusiveArea;    // 전용면적
     private Integer floor;            // 층
     private String address;           // 주소 (위치)
     private Integer views;            // 조회수

--- a/src/main/java/com/Realty/RealtyWeb/dto/HouseInfoDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/HouseInfoDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -17,12 +19,12 @@ public class HouseInfoDTO {
     private String buildingName; // 건물 이름
     private String purpose;      // 용도
     private String transactionType; // 거래 유형
-    private Double price;        // 가격
-    private Double maintenanceFee; // 관리비
+    private BigDecimal price;        // 가격
+    private BigDecimal maintenanceFee; // 관리비
     private String address;      // 주소
     private String addressDetail;// 상세 주소
-    private Double exclusiveArea;// 전용 면적
-    private Double supplyArea;   // 공급 면적
+    private BigDecimal exclusiveArea;// 전용 면적
+    private BigDecimal supplyArea;   // 공급 면적
     private Integer rooms;       // 방 개수
     private Integer bathrooms;   // 욕실 개수
     private Integer floor;       // 층수

--- a/src/main/java/com/Realty/RealtyWeb/dto/RegisterAnalysisDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/RegisterAnalysisDTO.java
@@ -1,0 +1,78 @@
+package com.Realty.RealtyWeb.dto;
+
+import com.Realty.RealtyWeb.Entity.RegisterAnalysisEntity;
+import com.Realty.RealtyWeb.enums.Purpose;
+import com.Realty.RealtyWeb.enums.RiskLevel;
+import com.Realty.RealtyWeb.enums.TransactionType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class RegisterAnalysisDTO {
+    private Long pid;
+    private String userid;
+
+    private String owner;
+    private LocalDateTime issueDate;
+
+    private String riskLevel;
+    private String riskKeywords;
+    private String mainWarnings;
+
+    private BigDecimal maxClaim;
+    private BigDecimal protectedAmount;
+
+    private Purpose purpose;
+    private TransactionType transactionType;
+    private BigDecimal price;
+    private BigDecimal exclusiveArea;
+
+    private String pdfBase64;
+
+    private List<RiskDetail> riskDetails;
+
+    // Entity -> DTO 매핑 정적 메서드
+
+    public static RegisterAnalysisEntity toEntity(RegisterAnalysisDTO dto) {
+        return RegisterAnalysisEntity.builder()
+                .userid(dto.getUserid())
+                .pid(dto.getPid())
+                .owner(dto.getOwner())
+                .issue_date(dto.getIssueDate())
+                .risk_level(RiskLevel.valueOf(dto.getRiskLevel()))
+                .risk_keywords(dto.getRiskKeywords())
+                .main_warnings(dto.getMainWarnings())
+                .max_claim(dto.getMaxClaim())
+                .protected_amount(dto.getProtectedAmount())
+                .purpose(Purpose.valueOf(dto.getPurpose().toString()))
+                .transactionType(TransactionType.valueOf(dto.getTransactionType().toString()))
+                .price(dto.getPrice())
+                .exclusiveArea(dto.getExclusiveArea())
+                .pdf_base64(dto.getPdfBase64())
+                .build();
+    }
+
+    public static RegisterAnalysisDTO fromEntity(RegisterAnalysisEntity entity) {
+        return RegisterAnalysisDTO.builder()
+                .userid(entity.getUserid())
+                .pid(entity.getPid())
+                .owner(entity.getOwner())
+                .issueDate(entity.getIssue_date())
+                .riskLevel(entity.getRisk_level().toString())
+                .riskKeywords(entity.getRisk_keywords())
+                .mainWarnings(entity.getMain_warnings())
+                .maxClaim(entity.getMax_claim())
+                .protectedAmount(entity.getProtected_amount())
+                .purpose(Purpose.valueOf(entity.getPurpose().toString()))
+                .transactionType(TransactionType.valueOf(entity.getTransactionType().toString()))
+                .price(entity.getPrice())
+                .exclusiveArea(entity.getExclusiveArea())
+                .pdfBase64(entity.getPdf_base64())
+                .build();
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/RiskDetail.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/RiskDetail.java
@@ -1,0 +1,13 @@
+package com.Realty.RealtyWeb.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RiskDetail {
+    private String keyword;
+    private String level;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/UnifiedRegisterResponseDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/UnifiedRegisterResponseDTO.java
@@ -1,0 +1,12 @@
+package com.Realty.RealtyWeb.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UnifiedRegisterResponseDTO {
+    private boolean requiresTwoWay;
+    private CodefTwoWayAuthResponseDTO twoWayInfo; // 2차 인증 필요 시
+    private CodefResponseDTO finalResult;          // 2차 없이 바로 응답 가능 시
+}

--- a/src/main/java/com/Realty/RealtyWeb/dto/UniqueNoRequestDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/UniqueNoRequestDTO.java
@@ -1,0 +1,38 @@
+package com.Realty.RealtyWeb.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UniqueNoRequestDTO {
+
+    private Long pid;
+    /* ───── 1차 요청에서 그대로 가져오는 필드 ───── */
+    @JsonProperty("organization")
+    private String organization;            // "0002"
+    @JsonProperty("phoneNo")
+    private String phoneNo;                 // 휴대폰번호
+    private String  password;
+    @JsonProperty("uniqueNo") // 평문 비밀번호
+    private String uniqueNo;
+    @JsonProperty("ePrepayNo")
+    private String  ePrepayNo;
+    @JsonProperty("ePrepayPass")
+    private String  ePrepayPass;
+    @JsonProperty("recordStatus")
+    private String  recordStatus;
+    @Builder.Default private String  inquiryType = "0";                                          // "1"
+    @Builder.Default private String  issueType = "1";                                            // "1"// 간편검색 주소
+    @Builder.Default private String  jointMortgageJeonseYN = "0";                                // "0"
+    @Builder.Default private String  tradingYN = "0";                                            // "0"
+    @Builder.Default private String  electronicClosedYN = "0";
+    @Builder.Default private String selectAddress = "0";
+    @Builder.Default private String isIdentityViewYN = "0";
+    @Builder.Default private String  originDataYN = "1";
+    @Builder.Default private String  warningSkipYN = "0";
+}
+

--- a/src/main/java/com/Realty/RealtyWeb/enums/RegionGuaranteeRule.java
+++ b/src/main/java/com/Realty/RealtyWeb/enums/RegionGuaranteeRule.java
@@ -1,0 +1,36 @@
+package com.Realty.RealtyWeb.enums;
+
+import java.math.BigDecimal;
+
+public enum RegionGuaranteeRule {
+
+    서울("서울특별시", new BigDecimal("50000000"), new BigDecimal("17000000")),
+    수도권("수도권 과밀억제권역", new BigDecimal("43000000"), new BigDecimal("15000000")),
+    광역시("광역시", new BigDecimal("37000000"), new BigDecimal("13000000")),
+    기타("그 외 지역", new BigDecimal("30000000"), new BigDecimal("11000000"));
+
+    private final String regionName;
+    private final BigDecimal guaranteeLimit;
+    private final BigDecimal maxPriorityRepayment;
+
+    RegionGuaranteeRule(String regionName, BigDecimal guaranteeLimit, BigDecimal maxPriorityRepayment) {
+        this.regionName = regionName;
+        this.guaranteeLimit = guaranteeLimit;
+        this.maxPriorityRepayment = maxPriorityRepayment;
+    }
+
+    public BigDecimal getGuaranteeLimit() {
+        return guaranteeLimit;
+    }
+
+    public BigDecimal getMaxPriorityRepayment() {
+        return maxPriorityRepayment;
+    }
+
+    public static RegionGuaranteeRule fromAddress(String address) {
+        if (address.contains("서울")) return 서울;
+        if (address.contains("과천") || address.contains("성남") || address.contains("부천") || address.contains("안양") || address.contains("군포") || address.contains("의왕") || address.contains("하남") || address.contains("광명")) return 수도권;
+        if (address.contains("부산") || address.contains("대구") || address.contains("인천") || address.contains("광주") || address.contains("대전") || address.contains("울산")) return 광역시;
+        return 기타;
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/enums/RiskKeywordRule.java
+++ b/src/main/java/com/Realty/RealtyWeb/enums/RiskKeywordRule.java
@@ -1,0 +1,64 @@
+package com.Realty.RealtyWeb.enums;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum RiskKeywordRule {
+
+    근저당권("주의", "매물을 담보로 받은 융자금이 있어요.",
+            "채권최고액과 보증금의 합이 시세의 70% 이하일 때 안전하다고 판단할 수 있어요."),
+
+    가압류("주의", "집이 법적 압류 상태예요.",
+            "채권자가 소송이나 빚 문제로 이 집에 대해 가압류를 걸어둔 상태예요. 계약 전 주의가 필요해요."),
+
+    가등기("위험", "소유권 이전 예약이 등록되어 있어요.", "가등기는 소유권 이전을 예약하는 등기로, 본등기로 전환될 경우 소유권이 이전될 수 있어요. 추후 분쟁의 소지가 있으므로 주의가 필요해요."),
+
+    가처분("주의", "부동산에 법적 분쟁이 걸려 있어요.",
+            "가처분은 법원이 부동산의 처분을 금지하는 조치로, 매매나 이전이 제한될 수 있어요. 계약 전에 법적 상태를 확인해야 해요."),
+
+    전세권설정("위험", "기존 세입자의 전세권이 등록되어 있어요.",
+            "보증금 회수 우선순위가 밀릴 수 있어요. 보호한도 초과 여부 확인이 필요해요."),
+
+    임차권등기명령("위험", "이전 세입자가 보증금을 못 받은 기록이 있어요.",
+            "보증금 회수가 어려울 수 있습니다. 새 입주자도 위험할 수 있어요."),
+
+    소유권이전등기("주의", "소유권 변동 가능성이 있어요.",
+            "집주인 또는 전문가와 소유권 변동에 대한 확인이 필요해요."),
+
+    공동담보설정("주의", "부동산이 공동담보로 설정되어 있어요.", "공동담보는 하나의 채권에 대해 여러 부동산이 담보로 설정된 것으로, 다른 부동산의 채무 불이행이 영향을 줄 수 있어요. "),
+
+    소유권보존등기("안전", "최초 소유권이 등록된 상태예요.", "일반적으로 문제가 없어요. 그러나 등기일과 실제 사용 상태를 확인해야 해요."),
+
+    경매개시결정("위험", "이 집이 경매 절차에 들어간 상태예요.",
+            "계약해도 경매 낙찰로 무효될 수 있어요."),
+
+    신탁("위험", "부동산이 신탁회사에 신탁되었어요.", "신탁은 부동산의 소유권이 신탁회사에 이전되어 관리되는 것으로, 계약 시 신탁 조건과 수익자의 권리를 확인해야 해요.");
+
+    private final String level;
+    private final String title;
+    private final String description;
+
+    RiskKeywordRule(String level, String title, String description) {
+        this.level = level;
+        this.title = title;
+        this.description = description;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static Optional<RiskKeywordRule> match(String raw) {
+        return Arrays.stream(values())
+                .filter(rule -> raw.replace(" ", "").contains(rule.name()))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/enums/RiskLevel.java
+++ b/src/main/java/com/Realty/RealtyWeb/enums/RiskLevel.java
@@ -1,0 +1,29 @@
+package com.Realty.RealtyWeb.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum RiskLevel {
+    안전("안전"),
+    주의("주의"),
+    위험("위험");
+
+    private final String value;
+
+    RiskLevel(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static RiskLevel fromValue(String value) {
+        for (RiskLevel riskLevel : RiskLevel.values()) {
+            if (riskLevel.value.equalsIgnoreCase(value)) {
+                return riskLevel;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value: " + value);
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/repository/RegisterAnalysisRepository.java
+++ b/src/main/java/com/Realty/RealtyWeb/repository/RegisterAnalysisRepository.java
@@ -1,0 +1,13 @@
+package com.Realty.RealtyWeb.repository;
+
+import com.Realty.RealtyWeb.Entity.RegisterAnalysisEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RegisterAnalysisRepository extends JpaRepository<RegisterAnalysisEntity, Long> {
+
+    List<RegisterAnalysisEntity> findAllByUserid(String userid);
+}

--- a/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterService.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterService.java
@@ -1,0 +1,31 @@
+package com.Realty.RealtyWeb.services;
+
+import com.Realty.RealtyWeb.dto.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+public interface CodefRegisterService {
+
+    /**
+     * 등기부등본 1차 요청: selectAddress 여부 포함
+     */
+    JsonNode requestRegisterFirst(CodefRequestDTO dto, String address) throws JsonProcessingException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, InvalidKeySpecException, BadPaddingException, InvalidKeyException, UnsupportedEncodingException, InterruptedException;
+
+    JsonNode requestByUnique(UniqueNoRequestDTO dto);
+
+    /**
+     * 응답에서 추가 인증 여부 확인 및 분기 판단용
+     */
+    boolean isTwoWayRequired(JsonNode response);
+
+    Long parseFinalResult(JsonNode response, Long pid, String userid, HouseInfoDTO houseInfo);
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterServiceImpl.java
@@ -1,0 +1,514 @@
+package com.Realty.RealtyWeb.services;
+
+import com.Realty.RealtyWeb.dto.*;
+import com.Realty.RealtyWeb.enums.Purpose;
+import com.Realty.RealtyWeb.enums.TransactionType;
+import com.Realty.RealtyWeb.services.analyzer.RegisterAnalyzer;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.codef.api.EasyCodef;
+import io.codef.api.EasyCodefServiceType;
+import io.codef.api.EasyCodefUtil;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CodefRegisterServiceImpl implements CodefRegisterService {
+
+    private final RegisterAnalysisService registerAnalysisService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final EasyCodef codef;
+
+
+    private final HashMap<String, HashMap<String, Object>> twoWayCache = new HashMap<>();
+
+
+    @Override
+    public JsonNode requestRegisterFirst(CodefRequestDTO dto, String address) throws JsonProcessingException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, InvalidKeySpecException, BadPaddingException, InvalidKeyException, UnsupportedEncodingException, InterruptedException {
+
+        String encPw = EasyCodefUtil.encryptRSA(dto.getPassword(), codef.getPublicKey());
+
+        HashMap<String, Object> params = buildBaseParam(dto, encPw, address);
+
+        String raw = codef.requestProduct(
+                "/v1/kr/public/ck/real-estate-register/status",
+                EasyCodefServiceType.DEMO,
+                params
+        );
+
+        JsonNode node = objectMapper.readTree(raw);
+
+        // 디버깅 로그 추가
+        System.out.println("▶ PARAM 디버깅");
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            System.out.println("  ↳ " + entry.getKey() + " = " + entry.getValue());
+        }
+
+
+        /* 추가 인증 필요? */
+        if (isTwoWayRequired(node)) {
+            // jti 를 캐시-키로 사용
+            String jti = node.path("data").path("jti").asText();
+            twoWayCache.put(jti, params);   // ← 1차 파라미터 저장
+        }
+        return node;                   // JSON 혹은 binary wrapper
+
+    }
+
+    @Override
+    public JsonNode requestByUnique(UniqueNoRequestDTO dto) {
+        try {
+            String encPw = EasyCodefUtil.encryptRSA(dto.getPassword(), codef.getPublicKey());
+
+            HashMap<String, Object> p = new HashMap<>();
+            p.put("organization", "0002");
+            p.put("phoneNo", dto.getPhoneNo());
+            p.put("password", encPw);
+
+            /* 핵심 차이점  */
+            p.put("uniqueNo", dto.getUniqueNo()); // 사용자가 고른 값
+
+            /* 선택 옵션 */
+            if (dto.getEPrepayNo() != null) p.put("ePrepayNo", dto.getEPrepayNo());
+            if (dto.getEPrepayPass() != null) p.put("ePrepayPass", dto.getEPrepayPass());
+            p.put("recordStatus", "0");
+            p.put("inquiryType", dto.getInquiryType());
+            p.put("issueType", dto.getIssueType());
+            p.put("jointMortgageJeonseYN", dto.getJointMortgageJeonseYN());
+            p.put("tradingYN", dto.getTradingYN());
+            p.put("electronicClosedYN", dto.getElectronicClosedYN());
+            p.put("selectAddress", dto.getSelectAddress());
+            p.put("isIdentityViewYN", dto.getIsIdentityViewYN());
+            p.put("originDataYN", dto.getOriginDataYN());
+            p.put("warningSkipYN", dto.getWarningSkipYN());
+
+            // ✅ 디버깅 로그 추가
+            System.out.println("▶ PARAM 디버깅");
+            for (Map.Entry<String, Object> entry : p.entrySet()) {
+                System.out.println("  ↳ " + entry.getKey() + " = " + entry.getValue());
+            }
+
+            String raw = codef.requestProduct(
+                    "/v1/kr/public/ck/real-estate-register/status",
+                    EasyCodefServiceType.DEMO,
+                    p);
+
+            raw = raw == null ? "" : raw.trim();
+
+            // ▸ percent-encoded JSON (예: "%7B%22result%22...")
+            if (raw.startsWith("%")) {
+                String decoded = URLDecoder.decode(raw, StandardCharsets.UTF_8);
+                return objectMapper.readTree(decoded);
+            }
+
+            // ▸ 정상 JSON
+            if (raw.startsWith("{") || raw.startsWith("[")) {
+                return objectMapper.readTree(raw);
+            }
+
+            // ▸ PDF(Base64) 등 바이너리
+            ObjectNode wrapper = objectMapper.createObjectNode();
+            wrapper.put("binaryData", raw);
+            return wrapper;
+
+        } catch (Exception e) {
+            throw new RuntimeException("고유번호 조회 실패", e);
+        }
+    }
+
+    @Override
+    public boolean isTwoWayRequired(JsonNode response) {
+        JsonNode data = response.path("data");
+        return data.has("continue2Way") && data.path("continue2Way").asBoolean();
+    }
+
+
+    private HashMap<String, Object> buildBaseParam(CodefRequestDTO dto, String encryptedPw, String address) {
+        HashMap<String, Object> p = new HashMap<>();
+        p.put("organization", "0002");
+        p.put("phoneNo", dto.getPhoneNo());
+        p.put("password", encryptedPw);
+        p.put("inquiryType", dto.getInquiryType());
+        p.put("issueType", dto.getIssueType());
+
+        // inquiryType == "1" 최소 필드
+        p.put("address", address);
+        p.put("recordStatus", dto.getRecordStatus());
+        p.put("jointMortgageJeonseYN", dto.getJointMortgageJeonseYN());
+        p.put("tradingYN", dto.getTradingYN());
+        p.put("electronicClosedYN", dto.getElectronicClosedYN());
+        p.put("selectAddress", "0");
+        p.put("ePrepayNo", dto.getEPrepayNo());
+        p.put("ePrepayPass", dto.getEPrepayPass());
+        p.put("originDataYN", dto.getOriginDataYN());
+        p.put("warningSkipYN", dto.getWarningSkipYN());
+        return p;
+    }
+
+    @Override
+    public Long parseFinalResult(JsonNode root, Long pid, String userId, HouseInfoDTO houseInfo) {
+
+        System.out.println("▶ 분석 응답 수신 (전체 JSON):\n" + root.toPrettyString());
+
+        try {
+            JsonNode dataNode = root.path("data");  // ✅ 핵심 변경
+// 로그 추가
+            System.out.println("▶ dataNode 구조 확인:");
+            System.out.println(dataNode.toPrettyString());
+
+            System.out.println("▶ dataNode 필드 목록:");
+            dataNode.fieldNames().forEachRemaining(f -> System.out.println(" - " + f));
+
+            // ───── 1. 기본 부동산 정보 추출 ─────
+            System.out.println("▶ 1단계: 기본 필드 추출 시작");
+
+            JsonNode entries = dataNode.path("resRegisterEntriesList");
+            if (entries == null || !entries.isArray() || entries.size() == 0) {
+                throw new IllegalArgumentException("resRegisterEntriesList가 존재하지 않음");
+            }
+
+            JsonNode entry = entries.get(0);
+            String address = entry.path("resRealty").asText();
+            String uniqueNo = entry.path("commUniqueNo").asText();
+            String issueRaw = entry.path("resPublishDate").asText(); // 예: "20250521"
+            String regOffice = entry.path("commCompetentRegistryOffice").asText();
+
+            System.out.println("  ↳ 주소: " + address);
+            System.out.println("  ↳ 고유번호: " + uniqueNo);
+            System.out.println("  ↳ 발급일자(raw): " + issueRaw);
+            System.out.println("  ↳ 등기소: " + regOffice);
+
+// ───── 2. 날짜 파싱 ─────
+            System.out.println("▶ 2단계: 발급일자 파싱");
+            LocalDateTime issueDate;
+
+            if (issueRaw.matches("\\d{8}")) {
+                // "yyyyMMdd" 형식
+                issueDate = LocalDate.parse(issueRaw, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
+            } else if (issueRaw.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}")) {
+                // "yyyy-MM-dd HH:mm:ss" 형식
+                issueDate = LocalDateTime.parse(issueRaw, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+            } else {
+                throw new IllegalArgumentException("지원하지 않는 발급일자 형식: " + issueRaw);
+            }
+
+            System.out.println("  ↳ 발급일자 파싱 완료: " + issueDate);
+
+            // ───── 3. 등기 내역 분석 ─────
+            System.out.println("▶ 3단계: 등기 내역 분석 시작");
+            JsonNode hisList = entry.path("resRegistrationHisList");
+            String owner = extractOwnerFromLatestTransfer(hisList);
+            if (hisList == null || !hisList.isArray()) {
+                throw new IllegalArgumentException("resRegistrationHisList가 존재하지 않음");
+            }
+            System.out.println("  ↳ 등록 내역 수: " + hisList.size());
+
+            RegisterAnalyzer.Result r = RegisterAnalyzer.analyze(hisList, address);
+            System.out.println("  ↳ 분석 완료 - 위험도: " + r.overallRisk);
+            System.out.println("  ↳ 최대 채권액: " + r.maxClaim);
+            System.out.println("  ↳ 보호 금액: " + r.protectedAmount);
+
+            // ───── 4. DB 저장용 DTO 생성 및 저장 ─────
+            System.out.println("▶ 4단계: RegisterAnalysisDTO 생성 및 저장");
+            RegisterAnalysisDTO analysisDto = RegisterAnalysisDTO.builder()
+                    .pid(pid)
+                    .owner(owner)
+                    .userid(userId)
+                    .issueDate(issueDate)
+                    .riskLevel(r.overallRisk)
+                    .riskKeywords(
+                            r.riskDetails.stream().map(RiskDetail::getKeyword)
+                                    .collect(Collectors.joining(", ")))
+                    .mainWarnings(
+                            r.riskDetails.stream()
+                                    .map(d -> d.getTitle() + " - " + d.getDescription())  // ✅ 제목 + 설명 결합
+                                    .collect(Collectors.joining(" / "))
+                    )
+                    .maxClaim(r.maxClaim)
+                    .protectedAmount(r.protectedAmount)
+                    .purpose(Purpose.valueOf(houseInfo.getPurpose()))
+                    .transactionType(TransactionType.valueOf(houseInfo.getTransactionType()))
+                    .price(houseInfo.getPrice())
+                    .exclusiveArea(houseInfo.getExclusiveArea())
+                    .pdfBase64(dataNode.path("resOriGinalData").asText())  // ✅ 수정
+                    .riskDetails(r.riskDetails)
+                    .build();
+
+
+            System.out.println("  ↳ DB 저장 완료");
+
+            // ───── 5. 클라이언트 응답 DTO 구성 ─────
+            System.out.println("▶ 5단계: 응답 DTO 구성 시작");
+
+            CodefResponseDTO.PropertyBasicInfo info = CodefResponseDTO.PropertyBasicInfo.builder()
+                    .resRealty(address)
+                    .resUserNm(owner)
+                    .commUniqueNo(uniqueNo)
+                    .resPublishDate(issueRaw)
+                    .commCompetentRegistryOffice(regOffice)
+                    .build();
+
+            List<CodefResponseDTO.RiskDetail> detailDtos = r.riskDetails.stream()
+                    .map(d -> CodefResponseDTO.RiskDetail.builder()
+                            .category(d.getTitle())
+                            .level(d.getLevel())
+                            .description(d.getDescription())
+                            .build())
+                    .toList();
+
+            CodefResponseDTO.RiskReport report = CodefResponseDTO.RiskReport.builder()
+                    .overallRisk(r.overallRisk)
+                    .risks(detailDtos)
+                    .build();
+
+            CodefResponseDTO finalDto = CodefResponseDTO.builder()
+                    .propertyInfo(info)
+                    .resOriGinalData(dataNode.path("resOriGinalData").asText())  // ✅ 수정
+                    .riskReport(report)
+                    .build();
+
+            System.out.println("▶ 최종 응답 구성 완료");
+            //return finalDto;
+            return registerAnalysisService.save(analysisDto);
+
+        } catch (Exception e) {
+            System.err.println("▶ 분석 중 예외 발생: " + e.getMessage());
+            e.printStackTrace();
+            throw new RuntimeException("등기부 분석 중 오류 발생", e);
+        }
+    }
+
+    private String extractOwnerFromLatestTransfer(JsonNode hisList) {
+        String fallback = "미상";
+        String lastMatchedContent = null;
+
+        for (int i = hisList.size() - 1; i >= 0; i--) {
+            JsonNode group = hisList.get(i);
+            if (!"갑구".equals(group.path("resType").asText())) continue;
+
+            JsonNode contentsList = group.path("resContentsList");
+
+            for (int j = contentsList.size() - 1; j >= 0; j--) {
+                JsonNode item = contentsList.get(j);
+                JsonNode detailList = item.path("resDetailList");
+
+                if (detailList.size() < 5) continue; // 필수 인덱스 존재 여부 확인
+
+                String purpose = detailList.get(1).path("resContents").asText().trim(); // 등기목적
+                if (!"소유권이전".equals(purpose)) continue;
+
+                // ✅ 이 항목이 우리가 원하는 마지막 "소유권이전" 항목
+                String content = detailList.get(4).path("resContents").asText();
+                lastMatchedContent = content;
+
+                // 바로 추출 시도
+                Matcher m = Pattern.compile("소유자\\s+([가-힣]{2,10})").matcher(content);
+                if (m.find()) {
+                    String owner = m.group(1);
+                    System.out.println("  ✅ 소유자 추출 성공: " + owner);
+                    return owner;
+                } else {
+                    System.out.println("  ⚠ 소유자 정규식 매칭 실패: " + content);
+                }
+            }
+        }
+
+        System.out.println("⚠ 소유권이전 항목은 있었지만 소유자 추출 실패 → fallback 사용");
+        if (lastMatchedContent != null) System.out.println("🔎 마지막 내용:\n" + lastMatchedContent);
+        return fallback;
+    }
+
+
+
+
+}
+/*
+    @Override
+    public JsonNode requestRegisterFirst(CodefRequestDTO dto) throws JsonProcessingException {
+        HashMap<String, Object> params = new HashMap<>();
+
+        try {
+            String rawPw = dto.getPassword();
+            String encryptedPw = EasyCodefUtil.encryptRSA(rawPw, codef.getPublicKey());
+
+            params.put("organization", "0002");
+            params.put("phoneNo", dto.getPhoneNo());
+            params.put("password", encryptedPw);
+            params.put("inquiryType", dto.getInquiryType());
+            params.put("issueType", dto.getIssueType());
+
+            // 타입 분기
+            switch (dto.getInquiryType()) {
+                case "0" -> {
+                    params.put("uniqueNo", dto.getUniqueNo());
+                    params.put("ePrepayNo", dto.getEPrepayNo());
+                    params.put("ePrepayPass", dto.getEPrepayPass());
+                }
+                case "1" -> {
+                    if (dto.getRealtyType() != null) params.put("realtyType", dto.getRealtyType());
+                    if (dto.getAddr_sido() != null) params.put("addr_sido", dto.getAddr_sido());
+                    if (dto.getAddress() != null) params.put("address", dto.getAddress());
+                    if (dto.getRecordStatus() != null) params.put("recordStatus", dto.getRecordStatus());
+                    if (dto.getStartPageNo() != null) params.put("startPageNo", dto.getStartPageNo());
+                    if (dto.getPageCount() != null) params.put("pageCount", dto.getPageCount());
+                    params.put("ePrepayNo", dto.getEPrepayNo());
+                    params.put("ePrepayPass", dto.getEPrepayPass());
+                }
+                case "2" -> {
+                    params.put("realtyType", dto.getRealtyType());
+                    params.put("addr_sido", dto.getAddr_sido());
+                    params.put("addr_dong", dto.getAddr_dong());
+                    params.put("addr_lotNumber", dto.getAddr_lotNumber());
+                    if ("1".equals(dto.getRealtyType())) params.put("inputSelect", dto.getInputSelect());
+                    if (dto.getBuildingName() != null) params.put("buildingName", dto.getBuildingName());
+                }
+                case "3" -> {
+                    params.put("addr_sigungu", dto.getAddr_sigungu());
+                    params.put("addr_roadName", dto.getAddr_roadName());
+                    params.put("addr_buildingNumber", dto.getAddr_buildingNumber());
+                }
+                default -> throw new IllegalArgumentException("inquiryType이 올바르지 않음: " + dto.getInquiryType());
+            }
+
+            if ("1".equals(dto.getRealtyType())) {
+                params.put("dong", dto.getDong());
+                params.put("ho", dto.getHo());
+                params.put("applicationType", dto.getApplicationType());
+            }
+            if (dto.getJointMortgageJeonseYN() != null) params.put("jointMortgageJeonseYN", dto.getJointMortgageJeonseYN());
+            if (dto.getTradingYN() != null) params.put("tradingYN", dto.getTradingYN());
+            if (dto.getListNumber() != null) params.put("listNumber", dto.getListNumber());
+            if (dto.getElectronicClosedYN() != null) params.put("electronicClosedYN", dto.getElectronicClosedYN());
+            if ("3".equals(dto.getIssueType()) && dto.getOriginData() != null)
+                params.put("originData", dto.getOriginData().replace("\n", "\\n"));
+            if (dto.getOriginDataYN() != null) params.put("originDataYN", dto.getOriginDataYN());
+            if (dto.getWarningSkipYN() != null) params.put("warningSkipYN", dto.getWarningSkipYN());
+            if (dto.getRegisterSummaryYN() != null) params.put("registerSummaryYN", dto.getRegisterSummaryYN());
+            if (dto.getSelectAddress() != null) params.put("selectAddress", dto.getSelectAddress());
+            if (dto.getIsIdentityViewYn() != null) params.put("isIdentityViewYn", dto.getIsIdentityViewYn());
+            if ("1".equals(dto.getIsIdentityViewYn()) && dto.getIdentityList() != null)
+                params.put("identityList", dto.getIdentityList());
+
+
+            // params.entrySet().removeIf(e -> e.getValue() == null);
+
+            // ✅ 디버깅 로그 추가
+            System.out.println("▶ PARAM 디버깅");
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                System.out.println("  ↳ " + entry.getKey() + " = " + entry.getValue());
+            }
+
+            // EasyCodef 요청
+            String productUrl = "/v1/kr/public/ck/real-estate-register/status";
+            String resultJson = codef.requestProduct(productUrl, EasyCodefServiceType.DEMO, params);
+
+            return objectMapper.readTree(resultJson);
+
+        } catch (Exception e) {
+            System.err.println("▶ 예외 발생: " + e.getMessage());
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                System.err.println("  ↳ " + entry.getKey() + " = " + entry.getValue());
+            }
+            throw new RuntimeException("등기부등본 요청 실패", e);
+        }
+    }
+
+
+
+    @Override
+    public CodefResponseDTO parseFinalResult(JsonNode response, Long pid, String userid) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 1. 기본 부동산 정보
+        JsonNode propertyNode = response.path("propertyBasicInfo");
+        String owner = propertyNode.path("resUserNm").asText();                    // 소유자명
+        String propertyName = propertyNode.path("resRealty").asText();            // 부동산명 (주소)
+        String uniqueNo = propertyNode.path("commUniqueNo").asText();             // 고유번호
+        String publishDate = propertyNode.path("resPublishDate").asText();        // 발급일자
+        String registryOffice = propertyNode.path("commCompetentRegistryOffice").asText(); // 등기소명
+
+        // 2. 발급일자 파싱
+        LocalDateTime issueDate = LocalDateTime.parse(publishDate, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        // 3. 등기 내역 분석
+        JsonNode regList = response.path("resRegistrationHisList");
+        RegisterAnalyzer.Result analysis = RegisterAnalyzer.analyze(regList, propertyName);
+        RegisterAnalysisDTO dto = RegisterAnalysisDTO.builder()
+                .pid(pid)
+                .userid(userid)
+                .owner(owner)
+                .issueDate(issueDate)
+                .riskLevel(analysis.overallRisk)
+                .riskKeywords(analysis.riskDetails.stream().map(RiskDetail::getTitle).collect(Collectors.joining(", ")))
+                .mainWarnings(analysis.riskDetails.stream().map(RiskDetail::getDescription).collect(Collectors.joining(" / ")))
+                .maxClaim(analysis.maxClaim)
+                .protectedAmount(analysis.protectedAmount)
+                .pdfBase64(response.path("resOriGinalData").asText())
+                .riskDetails(analysis.riskDetails)
+                .build();
+
+        registerAnalysisService.save(dto);
+
+        // 4. 기본 정보 DTO 구성
+        CodefResponseDTO.PropertyBasicInfo info = CodefResponseDTO.PropertyBasicInfo.builder()
+                .resUserNm(owner)
+                .resRealty(propertyName)
+                .commUniqueNo(uniqueNo)
+                .resPublishDate(publishDate)
+                .commCompetentRegistryOffice(registryOffice)
+                .build();
+
+        // 5. 리스크 상세 리스트 구성
+        List<CodefResponseDTO.RiskDetail> risks = analysis.riskDetails.stream()
+                .map(d -> CodefResponseDTO.RiskDetail.builder()
+                        .category(d.getTitle())
+                        .level(d.getLevel())
+                        .description(d.getDescription())
+                        .build())
+                .toList();
+
+        CodefResponseDTO.RiskReport report = CodefResponseDTO.RiskReport.builder()
+                .overallRisk(analysis.overallRisk)
+                .risks(risks)
+                .build();
+
+        // 6. 최종 응답 DTO 생성
+        return CodefResponseDTO.builder()
+                .propertyInfo(info)
+                .resOriGinalData(response.path("resOriGinalData").asText())
+                .riskReport(report)
+                .build();
+    }
+
+
+
+*/
+
+
+

--- a/src/main/java/com/Realty/RealtyWeb/services/CodefTokenService.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/CodefTokenService.java
@@ -1,0 +1,67 @@
+package com.Realty.RealtyWeb.services;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Service
+public class CodefTokenService {
+
+    @Value("${codef.client-id}")
+    private String clientId;
+
+    @Value("${codef.client-secret}")
+    private String clientSecret;
+
+    private String accessToken;
+    private long tokenExpiryTime;
+
+    private static final String TOKEN_URL = "https://oauth.codef.io/oauth/token";
+
+    public synchronized String getAccessToken() {
+        long now = System.currentTimeMillis();
+        if (accessToken == null || now >= tokenExpiryTime) {
+            refreshToken();
+        }
+        return accessToken;
+    }
+
+    private void refreshToken() {
+        try {
+            String params = "grant_type=client_credentials&scope=read";
+            String auth = Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(TOKEN_URL))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .header("Authorization", "Basic " + auth)
+                    .POST(HttpRequest.BodyPublishers.ofString(params))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                ObjectMapper mapper = new ObjectMapper();
+                Map<String, Object> tokenMap = mapper.readValue(response.body(), new TypeReference<>() {});
+                this.accessToken = (String) tokenMap.get("access_token");
+
+                int expiresIn = (int) tokenMap.get("expires_in"); // 보통 604800 (일주일)
+                this.tokenExpiryTime = System.currentTimeMillis() + (expiresIn - 60) * 1000L; // 1분 여유
+            } else {
+                throw new RuntimeException("토큰 요청 실패: " + response.statusCode());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Codef 토큰 갱신 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/services/HouseInfoService.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/HouseInfoService.java
@@ -13,4 +13,7 @@ public interface HouseInfoService {
 
     // 모든 매물 정보 조회
     List<HouseInfoDTO> getAllHouseInfos();
+
+    HouseInfoDTO findAddressByPid(Long pid);
+
 }

--- a/src/main/java/com/Realty/RealtyWeb/services/HouseInfoServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/HouseInfoServiceImpl.java
@@ -33,4 +33,13 @@ public class HouseInfoServiceImpl implements HouseInfoService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public HouseInfoDTO findAddressByPid(Long pid) {
+        return houseBoardRepository.findById(pid)
+                .flatMap(houseBoard -> houseInfoRepository.findByHouseBoardEntity(houseBoard))
+                .map(HouseInfoDTO::fromEntity) // ✅ DTO로 변환
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 pid입니다."));
+    }
+
+
 }

--- a/src/main/java/com/Realty/RealtyWeb/services/ImageServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/ImageServiceImpl.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 @Service
 public class ImageServiceImpl implements ImageService {
-    private final String uploadPath = "/home/realty/images/";
+    private final String uploadPath = "C:/realty/upload/images/";
 
 
     @Override

--- a/src/main/java/com/Realty/RealtyWeb/services/RegisterAnalysisService.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/RegisterAnalysisService.java
@@ -1,0 +1,17 @@
+package com.Realty.RealtyWeb.services;
+
+import com.Realty.RealtyWeb.dto.CodefResponseDTO;
+import com.Realty.RealtyWeb.dto.RegisterAnalysisDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+public interface RegisterAnalysisService {
+    Long save(RegisterAnalysisDTO dto);
+
+    RegisterAnalysisDTO getByIdAndUser(Long id, String userid);
+    List<RegisterAnalysisDTO> getAllByUser(String userid);
+
+    void deleteByIdAndUser(Long id, String userId);
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/services/RegisterAnalysisServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/RegisterAnalysisServiceImpl.java
@@ -1,0 +1,64 @@
+package com.Realty.RealtyWeb.services;
+
+import com.Realty.RealtyWeb.Entity.RegisterAnalysisEntity;
+import com.Realty.RealtyWeb.dto.CodefResponseDTO;
+import com.Realty.RealtyWeb.dto.CodefResponseDTO.*;
+import com.Realty.RealtyWeb.dto.RegisterAnalysisDTO;
+import com.Realty.RealtyWeb.repository.RegisterAnalysisRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterAnalysisServiceImpl implements RegisterAnalysisService {
+
+    private final RegisterAnalysisRepository registerAnalysisRepository;
+
+    @Override
+    public Long save(RegisterAnalysisDTO dto) {
+        RegisterAnalysisEntity entity = RegisterAnalysisDTO.toEntity(dto);
+        registerAnalysisRepository.save(entity);
+        return entity.getId();
+    }
+
+    @Override
+    public RegisterAnalysisDTO getByIdAndUser(Long id, String userid) {
+        RegisterAnalysisEntity entity = registerAnalysisRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("분석 결과를 찾을 수 없습니다."));
+
+        if (!entity.getUserid().equals(userid)) {
+            throw new AccessDeniedException("다른 사용자의 분석 결과는 조회할 수 없습니다.");
+
+        }
+
+        return RegisterAnalysisDTO.fromEntity(entity);
+    }
+
+    @Override
+    public List<RegisterAnalysisDTO> getAllByUser(String userid) {
+        return registerAnalysisRepository.findAllByUserid(userid).stream()
+                .map(RegisterAnalysisDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteByIdAndUser(Long id, String userId) {
+        RegisterAnalysisEntity entity = registerAnalysisRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("분석 결과를 찾을 수 없습니다."));
+
+        if (!entity.getUserid().equals(userId)) {
+            throw new AccessDeniedException("다른 사용자의 분석 결과는 삭제할 수 없습니다.");
+        }
+
+        registerAnalysisRepository.delete(entity);
+    }
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/services/analyzer/RegisterAnalyzer.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/analyzer/RegisterAnalyzer.java
@@ -1,0 +1,127 @@
+package com.Realty.RealtyWeb.services.analyzer;
+
+import com.Realty.RealtyWeb.dto.RiskDetail;
+import com.Realty.RealtyWeb.enums.RegionGuaranteeRule;
+import com.Realty.RealtyWeb.enums.RiskKeywordRule;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class RegisterAnalyzer {
+
+    public static class Result {
+        public List<RiskDetail> riskDetails;
+        public BigDecimal maxClaim;
+        public BigDecimal protectedAmount;
+        public String overallRisk;
+
+        public Result(List<RiskDetail> riskDetails, BigDecimal maxClaim, BigDecimal protectedAmount, String overallRisk) {
+            this.riskDetails = riskDetails;
+            this.maxClaim = maxClaim;
+            this.protectedAmount = protectedAmount;
+            this.overallRisk = overallRisk;
+        }
+    }
+
+    public static Result analyze(JsonNode resRegistrationHisList, String fullAddress) {
+        List<RiskDetail> result = new ArrayList<>();
+        BigDecimal maxClaim = BigDecimal.ZERO;
+
+        System.out.println("▶ 분석 시작: 등록 내역 수 = " + resRegistrationHisList.size());
+
+        for (JsonNode item : resRegistrationHisList) {
+            String resType = item.path("resType").asText();
+            System.out.println("  ↳ [resType=" + resType + "]");
+
+            if (!resType.equals("갑구") && !resType.equals("을구") && !resType.equals("표제부")) {
+                System.out.println("    → 무시됨 (비분석 대상)");
+                continue;
+            }
+
+            List<RiskDetail> keywordHits = extractRiskKeywords(item);
+            System.out.println("    → 위험 키워드 " + keywordHits.size() + "건 발견");
+
+            result.addAll(keywordHits);
+
+            if (resType.equals("을구")) {
+                BigDecimal claim = extractMaxClaim(item);
+                System.out.println("    → 채권최고액 추출: " + claim);
+                if (claim.compareTo(maxClaim) > 0) {
+                    maxClaim = claim;
+                }
+            }
+        }
+
+        RegionGuaranteeRule regionRule = RegionGuaranteeRule.fromAddress(fullAddress);
+        BigDecimal protectedAmount = regionRule.getGuaranteeLimit();
+        String overallRisk = calculateOverallRisk(result);
+
+        System.out.println("▶ 지역 보호한도: " + protectedAmount);
+        System.out.println("▶ 분석 총 위험 등급: " + overallRisk);
+
+        return new Result(result, maxClaim, protectedAmount, overallRisk);
+    }
+
+    private static BigDecimal extractMaxClaim(JsonNode item) {
+        try {
+            for (JsonNode entry : item.path("resContentsList")) {
+                for (JsonNode detail : entry.path("resDetailList")) {
+                    String content = detail.path("resContents").asText();
+                    Matcher m = Pattern.compile("채권최고액\\s*금?([\\d,]+)원").matcher(content);
+                    if (m.find()) {
+                        BigDecimal extracted = new BigDecimal(m.group(1).replace(",", ""));
+                        System.out.println("      → 채권최고액 탐지됨: " + extracted);
+                        return extracted;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("▶ 채권최고액 추출 실패: " + e.getMessage());
+        }
+        return BigDecimal.ZERO;
+    }
+
+    private static List<RiskDetail> extractRiskKeywords(JsonNode item) {
+        Set<RiskKeywordRule> detectedRules = new HashSet<>();
+
+        try {
+            for (JsonNode entry : item.path("resContentsList")) {
+                for (JsonNode detail : entry.path("resDetailList")) {
+                    String content = detail.path("resContents").asText();
+                    Optional<RiskKeywordRule> match = RiskKeywordRule.match(content);
+                    match.ifPresent(rule -> {
+                        if (detectedRules.add(rule)) {
+                            System.out.println("      → 키워드 발견: " + rule.name() + " / " + content);
+                        }
+                    });
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("▶ 키워드 분석 실패: " + e.getMessage());
+        }
+
+        // 중복 제거된 키워드만 RiskDetail로 변환
+        return detectedRules.stream()
+                .map(rule -> RiskDetail.builder()
+                        .level(rule.getLevel())
+                        .keyword(rule.name())
+                        .title(rule.getTitle())
+                        .description(rule.getDescription())
+                        .build())
+                .collect(Collectors.toList());
+
+    }
+
+
+    private static String calculateOverallRisk(List<RiskDetail> details) {
+        boolean hasHigh = details.stream().anyMatch(d -> "위험".equals(d.getLevel()));
+        boolean hasMid = details.stream().anyMatch(d -> "주의".equals(d.getLevel()));
+        if (hasHigh) return "위험";
+        if (hasMid) return "주의";
+        return "안전";
+    }
+}

--- a/src/main/java/com/Realty/RealtyWeb/token/JwtAuthenticationFilter.java
+++ b/src/main/java/com/Realty/RealtyWeb/token/JwtAuthenticationFilter.java
@@ -8,16 +8,33 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider; //Jwt 토큰을 생성하고 유저 정보를 저장하고 토큰를 전송할 수 있습니다
+    private static final AntPathMatcher matcher = new AntPathMatcher();
+
+    // 공개 URL
+    private static final List<String> PUBLIC_PATTERNS = List.of(
+            "/api/member/join",
+            "/api/auth/login",
+            "/api/auth/token/refresh",
+            "/api/member/list",
+            "/api/member/find-password",
+            "/api/codef/register",
+            "/api/codef/register/2way",
+            "/api/codef/register/auto",
+            "/api/codef/unique"
+    );
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -26,12 +43,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         log.info("[JwtAuthFilter] 요청 URI: {}", uri);
 
-        // 🔥 공개 URL은 무조건 통과
-        if (uri.startsWith("/api/member/join") ||
-                uri.startsWith("/api/auth/login") ||
-                uri.startsWith("/api/auth/token/refresh") ||
-                uri.startsWith("/api/member/list") ||
-                uri.startsWith("/api/member/find-password")) {
+//        // 🔥 공개 URL은 무조건 통과
+//        if (uri.startsWith("/api/member/join") ||
+//                uri.startsWith("/api/auth/login") ||
+//                uri.startsWith("/api/auth/token/refresh") ||
+//                uri.startsWith("/api/member/list") ||
+//                uri.startsWith("/api/member/find-password") ||
+//                uri.startsWith("/api/codef/register") ||
+//                uri.startsWith("/api/codef/register/2way") ||
+//                uri.startsWith("/api/codef/register/auto")) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
+
+        boolean isPublic = PUBLIC_PATTERNS.stream()
+                .anyMatch(pattern -> matcher.match(pattern, uri));
+
+        if (isPublic) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
- RegisterAnalyzer에 위험 키워드 및 채권최고액 추출 로직 추가
- 갑구·을구 항목 모두 분석 가능하도록 구조 확장
- 고유번호 기반 부동산 등기부 조회 API와 권리분석 연동 완료
- 분석 결과를 RegisterAnalysis 테이블에 저장하고, 최종 응답 DTO에 반영
- HouseBoard pid 기준으로 HouseInfo 주소 조회 및 자동 분석 연계 구현
- 디버깅 로깅 추가: 위험 키워드 감지, 채권최고액 탐지, 보호한도 계산 결과 출력