### PR TITLE
fix : 매물 게시글 이미지 수정 기능 추가 및 회원 프로필 이미지 기능 삭제

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,7 +9,7 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.4.1/8dfcdae21f559be9c8a4d6d515e77cfd1d9c06a8/spring-boot-configuration-processor-3.4.1.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.36/5a30490a6e14977d97d9c73c924c1f1b5311ea95/lombok-1.18.36.jar" />
         </processorPath>
-        <module name="com.Realty.RealtyWeb.main" />
+        <module name="RealtyWeb.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="21" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/RealtyWeb.iml" filepath="$PROJECT_DIR$/.idea/modules/RealtyWeb.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/RealtyWeb.test.iml" filepath="$PROJECT_DIR$/.idea/modules/RealtyWeb.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/RealtyWeb.main.iml" filepath="$PROJECT_DIR$/.idea/modules/RealtyWeb.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.Realty.RealtyWeb.main.iml" filepath="$PROJECT_DIR$/.idea/modules/com.Realty.RealtyWeb.main.iml" />
     </modules>
   </component>

--- a/.idea/modules/RealtyWeb.main.iml
+++ b/.idea/modules/RealtyWeb.main.iml
@@ -5,16 +5,4 @@
       <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
     </content>
   </component>
-  <component name="FacetManager">
-    <facet type="jpa" name="JPA">
-      <configuration>
-        <setting name="validation-enabled" value="true" />
-        <setting name="provider-name" value="Hibernate" />
-        <datasource-mapping>
-          <factory-entry name="entityManagerFactory" />
-        </datasource-mapping>
-        <naming-strategy-map />
-      </configuration>
-    </facet>
-  </component>
 </module>

--- a/src/main/java/com/Realty/RealtyWeb/Config/StaticResourceConfig.java
+++ b/src/main/java/com/Realty/RealtyWeb/Config/StaticResourceConfig.java
@@ -1,0 +1,16 @@
+package com.Realty.RealtyWeb.Config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration // 이미지 정적 리소스 등록
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:///C:/realty/upload/images/");
+    }
+
+}

--- a/src/main/java/com/Realty/RealtyWeb/Config/WebSecurityConfig.java
+++ b/src/main/java/com/Realty/RealtyWeb/Config/WebSecurityConfig.java
@@ -55,6 +55,7 @@ public class WebSecurityConfig{
         }));
             http.csrf(csrf -> csrf.disable())
                     .authorizeHttpRequests((requests) -> requests
+                            .requestMatchers("/images/**").permitAll()
                             .requestMatchers("/api/member/join").permitAll()
                             .requestMatchers("/api/auth/login").permitAll() //공개 경로 이따가 적어둬야함.
                             .requestMatchers("/api/auth/token/refresh").permitAll()

--- a/src/main/java/com/Realty/RealtyWeb/Entity/UserEntity.java
+++ b/src/main/java/com/Realty/RealtyWeb/Entity/UserEntity.java
@@ -33,9 +33,6 @@ public class UserEntity implements UserDetails {
     @Column(name = "userphone", length = 20, unique = true)
     private String userPhone;
 
-    @Column(name = "userimg", length = 255, unique = true)
-    private String userImg;
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList();  // 현재는 ROLE 없음

--- a/src/main/java/com/Realty/RealtyWeb/controller/MemberController.java
+++ b/src/main/java/com/Realty/RealtyWeb/controller/MemberController.java
@@ -22,18 +22,19 @@ import java.util.Map;
 public class MemberController {
 
     private final MemberService memberService;
-    private final ImageService imageService;
 
     //회원가입
     //multipart 적용
-    @PostMapping(value = "/join", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<MemberDTO> join(
-            @RequestPart("data") MemberSignUpDTO signUpDTO,
-            @RequestPart(value = "userimg", required = false) MultipartFile userimg) {
-        String imageUrl = imageService.save(userimg); // 이미지 저장 처리
-        signUpDTO.setUserImg(imageUrl);
-        MemberDTO member = memberService.join(signUpDTO);
-        return ResponseEntity.status(HttpStatus.CREATED).body(member);
+    @PostMapping(value = "/join")
+    public ResponseEntity<?> join(
+            @RequestBody MemberSignUpDTO signUpDTO) {
+        try {
+            MemberDTO member = memberService.join(signUpDTO);
+            return ResponseEntity.status(HttpStatus.CREATED).body(member);
+        } catch (IllegalArgumentException e) {
+            // ⚠ 클라이언트가 알 수 있도록 400 에러와 메시지 전달
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
     }
 
     //id 중복체크

--- a/src/main/java/com/Realty/RealtyWeb/dto/MemberDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/MemberDTO.java
@@ -12,5 +12,4 @@ public class MemberDTO {
     private String userName;
     private String userEmail;
     private String userPhone;
-    private String userImg;
 }

--- a/src/main/java/com/Realty/RealtyWeb/dto/MemberSignUpDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/MemberSignUpDTO.java
@@ -13,6 +13,5 @@ public class MemberSignUpDTO {
     private String userName;
     private String userPhone;
     private String userEmail;
-    private String userImg;
 
 }

--- a/src/main/java/com/Realty/RealtyWeb/dto/RegisterAnalysisDTO.java
+++ b/src/main/java/com/Realty/RealtyWeb/dto/RegisterAnalysisDTO.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Data
 @Builder
 public class RegisterAnalysisDTO {
+    private Long id;
     private Long pid;
     private String userid;
 
@@ -37,10 +38,11 @@ public class RegisterAnalysisDTO {
 
     private List<RiskDetail> riskDetails;
 
-    // Entity -> DTO 매핑 정적 메서드
+    // DTO -> 엔티티
 
     public static RegisterAnalysisEntity toEntity(RegisterAnalysisDTO dto) {
         return RegisterAnalysisEntity.builder()
+                .id(dto.getId())
                 .userid(dto.getUserid())
                 .pid(dto.getPid())
                 .owner(dto.getOwner())
@@ -59,8 +61,10 @@ public class RegisterAnalysisDTO {
                 .build();
     }
 
+    // 엔티티 -> DTO
     public static RegisterAnalysisDTO fromEntity(RegisterAnalysisEntity entity) {
         return RegisterAnalysisDTO.builder()
+                .id(entity.getId())
                 .userid(entity.getUserid())
                 .pid(entity.getPid())
                 .owner(entity.getOwner())

--- a/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/CodefRegisterServiceImpl.java
@@ -46,9 +46,10 @@ public class CodefRegisterServiceImpl implements CodefRegisterService {
     private final EasyCodef codef;
 
 
-    private final HashMap<String, HashMap<String, Object>> twoWayCache = new HashMap<>();
+    // private final HashMap<String, HashMap<String, Object>> twoWayCache = new HashMap<>();
+    // twoWayCache 사실 필요없음
 
-
+    // 이건 2차 인증 걸러내기 용
     @Override
     public JsonNode requestRegisterFirst(CodefRequestDTO dto, String address) throws JsonProcessingException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, InvalidKeySpecException, BadPaddingException, InvalidKeyException, UnsupportedEncodingException, InterruptedException {
 
@@ -71,16 +72,17 @@ public class CodefRegisterServiceImpl implements CodefRegisterService {
         }
 
 
-        /* 추가 인증 필요? */
-        if (isTwoWayRequired(node)) {
-            // jti 를 캐시-키로 사용
-            String jti = node.path("data").path("jti").asText();
-            twoWayCache.put(jti, params);   // ← 1차 파라미터 저장
-        }
+//        /* 추가 인증 필요 - 이것도 필요없긴 함 */
+//        if (isTwoWayRequired(node)) {
+//            // jti 를 캐시-키로 사용
+//            String jti = node.path("data").path("jti").asText();
+//            twoWayCache.put(jti, params);   // ← 1차 파라미터 저장
+//        }
         return node;                   // JSON 혹은 binary wrapper
 
     }
 
+    // 얘가 메인
     @Override
     public JsonNode requestByUnique(UniqueNoRequestDTO dto) {
         try {

--- a/src/main/java/com/Realty/RealtyWeb/services/MemberServiceImpl.java
+++ b/src/main/java/com/Realty/RealtyWeb/services/MemberServiceImpl.java
@@ -36,6 +36,8 @@ public class MemberServiceImpl implements MemberService {
             throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
         }else if (checkName(signUpDTO.getUserName())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }else if (checkEmail(signUpDTO.getUserEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
 
         String hashedPw = passwordEncoder.encode(signUpDTO.getUserPw());
@@ -47,7 +49,6 @@ public class MemberServiceImpl implements MemberService {
                 .userName(signUpDTO.getUserName())
                 .userPhone(signUpDTO.getUserPhone())
                 .userEmail(signUpDTO.getUserEmail())
-                .userImg(signUpDTO.getUserImg())
                 .build();
 
         memberRepository.save(userEntity);
@@ -57,8 +58,8 @@ public class MemberServiceImpl implements MemberService {
                 signUpDTO.getUserId(),
                 signUpDTO.getUserName(),
                 signUpDTO.getUserEmail(),
-                signUpDTO.getUserPhone(),
-                signUpDTO.getUserImg());
+                signUpDTO.getUserPhone()
+        );
     }
 
     //특정 회원 조회
@@ -70,7 +71,6 @@ public class MemberServiceImpl implements MemberService {
                         .userName(member.getDisplayName())
                         .userEmail(member.getUserEmail())
                         .userPhone(member.getUserPhone())
-                        .userImg(member.getUserImg())
                         .build());
     }
 
@@ -84,7 +84,6 @@ public class MemberServiceImpl implements MemberService {
                         .userName(member.getDisplayName())
                         .userEmail(member.getUserEmail())
                         .userPhone(member.getUserPhone())
-                        .userImg(member.getUserImg())
                         .build())
                 .toList(); //Stream -> List
     }
@@ -128,7 +127,6 @@ public class MemberServiceImpl implements MemberService {
             user.setUserName(memberDTO.getUserName());
             user.setUserEmail(memberDTO.getUserEmail());
             user.setUserPhone(memberDTO.getUserPhone());
-            user.setUserImg(memberDTO.getUserImg());
             UserEntity updatedUser = memberRepository.save(user);
 
             return MemberDTO.builder()
@@ -136,7 +134,6 @@ public class MemberServiceImpl implements MemberService {
                     .userName(updatedUser.getDisplayName())
                     .userEmail(updatedUser.getUserEmail())
                     .userPhone(updatedUser.getUserPhone())
-                    .userImg(updatedUser.getUserImg())
                     .build();
         }).orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }

--- a/src/main/java/com/Realty/RealtyWeb/token/JwtAuthenticationFilter.java
+++ b/src/main/java/com/Realty/RealtyWeb/token/JwtAuthenticationFilter.java
@@ -26,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final List<String> PUBLIC_PATTERNS = List.of(
             "/api/member/join",
             "/api/auth/login",
+            "/images/**",
             "/api/auth/token/refresh",
             "/api/member/list",
             "/api/member/find-password",


### PR DESCRIPTION
- PUT /api/house-board/update/{pid}에서 Multipart 형식으로 이미지 수정 가능하도록 컨트롤러 수정
- @RequestPart 방식 적용, 기존 이미지 유지 또는 덮어쓰기 로직 반영
- /images/** 경로에 대한 정적 리소스 매핑 추가 (file:///C:/realty/upload/images/)
- WebSecurityConfig에 /images/** permitAll 설정 추가 (JWT 없이 접근 가능)
- JwtAuthenticationFilter에 /images/** 공개 경로로 추가하여 필터 우회
- Postman 테스트 완료